### PR TITLE
update watch ''app/pages/**/*.scss"

### DIFF
--- a/sass-build/index.js
+++ b/sass-build/index.js
@@ -4,7 +4,10 @@ var gulp = require('gulp'),
     assign = require('lodash.assign');
 
 var defaultOptions = {
-  src: 'app/theme/app.+(ios|md|wp).scss',
+  src:  [
+    'app/theme/app.+(ios|md|wp).scss',
+    'app/pages/**/*.scss'
+  ],
   dest: 'www/build/css',
   sassOptions: {
     includePaths: [


### PR DESCRIPTION
Ionic2 beta.4's gulpfile is watch 'app/**/*.scss'. so when ''app/pages/**/*.scss"  is changed, browser live reloaded.
But now, don't make css file.

Angular2 have function css capsuled and Ionic2 can use this.

example.

> @Page({
>   styleUrls  : ['build/css/index/index.css'],
> })

so I think ionic-gulp-sass-build must watch ''app/pages/*_/_.scss'.

thanks.
