### PR TITLE
Added asset-copy task to include any images into the build folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The current list of tasks is:
 - [Fonts copy task](./fonts-copy)
 - [HTML copy task](./html-copy)
 - [Scripts copy task](./scripts-copy)
+- [Asset copy task](./assets-copy)
 
 #### Usage
 
@@ -31,7 +32,7 @@ gulp.task('build', buildWebpack);
 Each task takes an optional options object:
 ```
   gulp.task('watch', function(){
-    return webpackBuild({ watch: true });  
+    return webpackBuild({ watch: true });
   });
 ```
 

--- a/assets-copy/README.md
+++ b/assets-copy/README.md
@@ -1,0 +1,30 @@
+# Asset Copy Task
+Copy Assets sources to build directory.
+
+## API
+
+### copyAssets([options])
+
+Returns a [stream](http://nodejs.org/api/stream.html) of [Vinyl files](https://github.com/wearefractal/vinyl-fs)
+that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options).
+
+#### Available options:
+- **src** (String|Array) Glob or array of globs ([What's a glob?](https://github.com/isaacs/node-glob#glob-primer)) matching HTML source files. Default: `'app/assets/**'`.
+- **dest** (String) Output path for the Asset files. Default: `'www/build/assets/'`.
+
+## Example
+
+```
+var copyAssets = require('ionic-gulp-assets-copy');
+
+gulp.task('html', copyAssets);
+
+gulp.task('html', function(){
+  return copyAssets({ dest: 'www/my-custom-asset-dir' });
+});
+```
+
+
+
+
+

--- a/assets-copy/index.js
+++ b/assets-copy/index.js
@@ -1,0 +1,9 @@
+var gulp = require('gulp');
+
+module.exports = function(options) {
+  options.src = options.src || 'app/assets/**';
+  options.dest = options.dest || 'www/build/assets/';
+
+  return gulp.src(options.src)
+    .pipe(gulp.dest(options.dest));
+}

--- a/assets-copy/package.json
+++ b/assets-copy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ionic-gulp-assets-copy",
+  "description": "Gulp task for Ionic projects to copy Asset sources to a build directory",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/driftyco/ionic-gulp-tasks.git"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "gulp": "^3.9.1"
+  }
+}


### PR DESCRIPTION
Why make my own when I can contribute to yours :)

I found it of need in a couple of my projects to I thought of proposing its addition
- Added asset-copy folder that includes the export of the task
- Just copies all files from app/assets to build/assets

If merged, it'll just need to be published by the team
