### PR TITLE
Propogate webpack errors

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -6,6 +6,7 @@ var defaultOptions = {
   watch: false,
   watchOptions: null,
   config: null,
+  failOnWarning: false,
   statsOptions: {
     'colors': true,
     'modules': false,
@@ -27,6 +28,11 @@ module.exports = function(options) {
   function webpackCallback(err, stats) {
     // print build stats and errors
     console.log(stats.toString(options.statsOptions));
+    if (stats.hasErrors() || 
+      (stats.hasWarnings() && options.failOnWarning)) {
+      deferred.reject(err);
+    }
+    
     deferred.resolve();
   }
 


### PR DESCRIPTION
The current implementation does not allow users of ionic-gulp-webpack to detect failures of the build. Knowing when the build fails is important when having a CI system with rolling builds.
This pull request changes the task to reject the returned promise on errors and warnings (optional).
