### PR TITLE
Adding copyCSS gulp task so we can copy CSS sources to build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The current list of tasks is:
 - [Sass build task](./sass-build)
 - [Fonts copy task](./fonts-copy)
 - [HTML copy task](./html-copy)
+- [CSS copy task](./css-copy)
 - [Scripts copy task](./scripts-copy)
 - [*ESlint task](https://github.com/devillex/ionic-gulp-eslint)
 

--- a/css-copy/README.md
+++ b/css-copy/README.md
@@ -1,0 +1,30 @@
+# CSS Copy Task
+Copy CSS sources to build directory.
+
+## API
+
+### copyCSS([options])
+
+Returns a [stream](http://nodejs.org/api/stream.html) of [Vinyl files](https://github.com/wearefractal/vinyl-fs)
+that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options).
+
+#### Available options:
+- **src** (String|Array) Glob or array of globs ([What's a glob?](https://github.com/isaacs/node-glob#glob-primer)) matching CSS source files. Default: `'app/**/*.css'`.
+- **dest** (String) Output path for the CSS files. Default: `'www/build'`.
+
+## Example
+
+```
+var copyCSS = require('ionic-gulp-css-copy');
+
+gulp.task('css', copyCSS);
+
+gulp.task('css', function(){
+  return copyCSS({ dest: 'www/my-custom-build-dir' });
+});
+```
+
+
+
+
+

--- a/css-copy/index.js
+++ b/css-copy/index.js
@@ -1,0 +1,9 @@
+var gulp = require('gulp');
+
+module.exports = function(options) {
+  options.src = options.src || 'app/**/*.css';
+  options.dest = options.dest || 'www/build';
+
+  return gulp.src(options.src)
+    .pipe(gulp.dest(options.dest));
+}

--- a/css-copy/package.json
+++ b/css-copy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ionic-gulp-css-copy",
+  "description": "Gulp task for Ionic projects to copy CSS sources to a build directory",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/driftyco/ionic-gulp-tasks.git"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "gulp": "^3.9.1"
+  }
+}


### PR DESCRIPTION
Since the release of the [Angular2 style guide](https://angular.io/docs/ts/latest/guide/style-guide.html) it's suggested that we "Do extract templates and styles into a separate file, when more than 3 lines." I'm aware ionic is using sass, but I think `styleUrls` comes in handy for encapsulation of components. For this purpose I have added a gulp task which mimics copyHTML for the purpose of copying css files to the `www/` directory. 
