### PR TITLE
added envify

### DIFF
--- a/browserify-es2015/index.js
+++ b/browserify-es2015/index.js
@@ -4,6 +4,7 @@ var gulp = require('gulp'),
     babelES2015Preset = require('babel-preset-es2015'),
     browserify = require('browserify'),
     watchify = require('watchify'),
+    envify = require('envify'),
     pretty = require('prettysize'),
     merge = require('lodash.merge'),
     source = require('vinyl-source-stream'),
@@ -44,6 +45,10 @@ module.exports = function(options) {
 
   var b = browserify(options.src, options.browserifyOptions)
     .transform(babelify, options.babelifyOptions);
+
+  if (options.envifyOptions) {
+    b.transform(envify, options.envifyOptions);
+  }
 
   if (options.watch) {
     b = watchify(b, options.watchifyOptions);

--- a/browserify-es2015/package.json
+++ b/browserify-es2015/package.json
@@ -12,6 +12,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "envify": "^3.4.0",
     "gulp": "^3.9.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.3",


### PR DESCRIPTION
Hi guys,

I ran into a situation where I needed to pass some env variables to the ionic build. This pull request adds support for [envify](https://github.com/hughsk/envify). This should allow to pass variables from gulp like this:

``` js
gulp.task('build', ['clean'], function(done){
  runSequence(
    ['sass', 'html', 'fonts', 'scripts'],
    function(){
      buildBrowserify({
        minify: isRelease,
        browserifyOptions: {
          debug: !isRelease
        },
        uglifyOptions: {
          mangle: false
        },
        envifyOptions: { ENV: 'production' } 
      }).on('end', done);
    }
  );
});
```

and later access them with:

``` js
if (process.env.ENV == "production") {
 // do something
}
```

It looks like some other people asked about it too:

https://forum.ionicframework.com/t/debate-ionic-2-environment-development-variables-setup/44061
