### PR TITLE
Changed browserify-typescript source definition file from "main.d.ts"…

### DIFF
--- a/browserify-typescript/index.js
+++ b/browserify-typescript/index.js
@@ -12,7 +12,7 @@ var gulp = require('gulp'),
 
 var defaultOptions = {
   watch: false,
-  src: ['./app/app.ts', './typings/main.d.ts'],
+  src: ['./app/app.ts', './typings/index.d.ts'],
   outputPath: 'www/build/js/',
   outputFile: 'app.bundle.js',
   minify: false,


### PR DESCRIPTION
… to "index.d.ts", the "main" file name is deprecated in typings 1.x

Following this issue: https://github.com/driftyco/ionic-gulp-tasks/issues/23
Since typings 1.x, the "main.d.ts" file was renamed to "index.d.ts".
