### PR TITLE
Compat with Typings 1.0

### DIFF
--- a/browserify-typescript/index.js
+++ b/browserify-typescript/index.js
@@ -12,7 +12,7 @@ var gulp = require('gulp'),
 
 var defaultOptions = {
   watch: false,
-  src: ['./app/app.ts', './typings/main.d.ts'],
+  src: ['./app/app.ts', './typings/index.d.ts'],
   outputPath: 'www/build/js/',
   outputFile: 'app.bundle.js',
   minify: false,


### PR DESCRIPTION
As of version 1.0 the Typings bundle file's name has changed to `index.d.ts`

Until this is fixed a remedial step you can take is to override the src array in your gulpfile:

`buildBrowserify({
          src: ['./app/app.ts', './typings/index.d.ts'],
          watch: true
      })`

See [v1.0 release notes](https://github.com/typings/typings/blob/b79fd3f0f9af245a790717dcb5493fb49db2788d/README.md) for more context.
