### PR TITLE
fix: sourceRoot in sourceMaps

### DIFF
--- a/browserify-typescript/index.js
+++ b/browserify-typescript/index.js
@@ -55,7 +55,7 @@ module.exports = function(options) {
       .pipe(buffer())
       .pipe(debug ? sourcemaps.init({ loadMaps: true }) : noop())
       .pipe(options.minify ? uglify(options.uglifyOptions) : noop())
-      .pipe(debug ? sourcemaps.write('./') : noop())
+      .pipe(debug ? sourcemaps.write('./',{includeContent:false, sourceRoot:'../../../'}) : noop())
       .pipe(gulp.dest(options.outputPath));
   }
 

--- a/scripts-copy/index.js
+++ b/scripts-copy/index.js
@@ -2,8 +2,10 @@ var gulp = require('gulp');
 
 var defaultSrc = [
   'node_modules/es6-shim/es6-shim.min.js',
+  'node_modules/es6-shim/es6-shim.map',
   'node_modules/zone.js/dist/zone.js',
-  'node_modules/reflect-metadata/Reflect.js'
+  'node_modules/reflect-metadata/Reflect.js',
+  'node_modules/reflect-metadata/Reflect.js.map'
 ];
 
 module.exports = function(options) {


### PR DESCRIPTION
Configure browserify with sourceMaps and sourceRoot
Copy existing maps for es6-shim and reflect-metadata
