### PR TITLE
Fix for Issue #4986: Unable to Including third party libraries (like lodash) for Ionic 2 using TypeScript setup 

### DIFF
--- a/browserify-typescript/index.js
+++ b/browserify-typescript/index.js
@@ -12,7 +12,7 @@ var gulp = require('gulp'),
 
 var defaultOptions = {
   watch: false,
-  src: ['./app/app.ts', './typings/main.d.ts'],
+  src: ['./app/app.ts', './typings/index.d.ts'],
   outputPath: 'www/build/js/',
   outputFile: 'app.bundle.js',
   minify: false,

--- a/browserify-typescript/package.json
+++ b/browserify-typescript/package.json
@@ -14,7 +14,7 @@
     "gulp-uglify": "^1.5.3",
     "lodash.merge": "^4.3.2",
     "prettysize": "0.0.3",
-    "tsify": "^0.14.1",
+    "tsify": "^0.16.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Unable to include third party node modules in ionic2 typescript. 

1) Updated tsify version to 0.16.0 for ionic-gulp-browserify-typescript.
2) Use index.d.ts insted of main.d.ts 

Note: typeings version 1.3.0 
