### PR TITLE
feat: add generic copy task

### DIFF
--- a/generic-copy/README.md
+++ b/generic-copy/README.md
@@ -10,7 +10,9 @@ that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_desti
 
 #### Required options:
 - **src** (String|Array) Glob or array of globs ([What's a glob?](https://github.com/isaacs/node-glob#glob-primer)) matching HTML source files.
-- **dest** (String) Output path for the HTML files.
+
+#### Available options:
+- **dest** (String) Output path for the HTML files. Default: `'www/build'`.
 
 ## Example
 
@@ -20,7 +22,7 @@ var copyData= require('ionic-gulp-generic-copy');
 gulp.task('data', function(){
   return copyGeneric({
       src: 'app/data/**/*.json',
-      dest: 'www/data'
+      dest: 'www/build/data'
     });
 });
 ```

--- a/generic-copy/README.md
+++ b/generic-copy/README.md
@@ -1,0 +1,31 @@
+# Generic Copy Task
+Copy Generic sources to build directory.
+
+## API
+
+### copyGeneric({options})
+
+Returns a [stream](http://nodejs.org/api/stream.html) of [Vinyl files](https://github.com/wearefractal/vinyl-fs)
+that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options).
+
+#### Required options:
+- **src** (String|Array) Glob or array of globs ([What's a glob?](https://github.com/isaacs/node-glob#glob-primer)) matching HTML source files.
+- **dest** (String) Output path for the HTML files.
+
+## Example
+
+```
+var copyData= require('ionic-gulp-generic-copy');
+
+gulp.task('data', function(){
+  return copyGeneric({
+      src: 'app/data/**/*.json',
+      dest: 'www/data'
+    });
+});
+```
+
+
+
+
+

--- a/generic-copy/index.js
+++ b/generic-copy/index.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp');
+
+module.exports = function(options) {
+  if(!options || !options.src  || !options.dest) {
+    return;
+  }
+
+  return gulp.src(options.src)
+    .pipe(gulp.dest(options.dest));
+}

--- a/generic-copy/index.js
+++ b/generic-copy/index.js
@@ -1,9 +1,11 @@
 var gulp = require('gulp');
 
 module.exports = function(options) {
-  if(!options || !options.src  || !options.dest) {
+  if(!options || !options.src) {
     return;
   }
+
+  options.dest = options.dest || 'www/build';
 
   return gulp.src(options.src)
     .pipe(gulp.dest(options.dest));

--- a/generic-copy/package.json
+++ b/generic-copy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ionic-gulp-generic-copy",
+  "description": "Gulp task for Ionic projects to copy generic sources to a build directory",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/driftyco/ionic-gulp-tasks.git"
+  },
+  "version": "1.0.0",
+  "dependencies": {
+    "gulp": "^3.9.1"
+  }
+}


### PR DESCRIPTION
Add a gulp task that allows generic copying of files from a source to a destination.
