### PR TITLE
Add extra config. options to sass-build

### DIFF
--- a/sass-build/README.md
+++ b/sass-build/README.md
@@ -10,6 +10,7 @@ that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_desti
 
 #### Available options:
 - **src** (String|Array) Glob or array of globs ([What's a glob?](https://github.com/isaacs/node-glob#glob-primer)) matching Sass entry files. Default: `'app/theme/app.+(ios|md|wp).scss'`.
+- **srcOptions** (Object) An object passed as second argument to [`gulp.src`](https://github.com/gulpjs/gulp/blob/master/docs/API.md#options). Default `{}`.
 - **dest** (String) Output path for the compiled CSS bundle(s). Default: `'www/build/css'`.
 - **sassOptions** (Object) [Sass options](https://github.com/sass/node-sass#options). Default:
 ```
@@ -61,8 +62,3 @@ gulp.task('sass', function(){
   });
 });
 ```
-
-
-
-
-

--- a/sass-build/README.md
+++ b/sass-build/README.md
@@ -13,6 +13,7 @@ that can be [piped](http://nodejs.org/api/stream.html#stream_readable_pipe_desti
 - **srcOptions** (Object) An object passed as second argument to [`gulp.src`](https://github.com/gulpjs/gulp/blob/master/docs/API.md#options). Default `{}`.
 - **dest** (String) Output path for the compiled CSS bundle(s). Default: `'www/build/css'`.
 - **sassOptions** (Object) [Sass options](https://github.com/sass/node-sass#options). Default:
+- **hookFunction** (Function) A function that takes the sass stream as input and returns a stream. Useful if additional transformations need to be piped. Default:
 ```
 {
   includePaths: [

--- a/sass-build/index.js
+++ b/sass-build/index.js
@@ -1,10 +1,11 @@
 var gulp = require('gulp'),
     sass = require('gulp-sass'),
-    autoprefixer = require('gulp-autoprefixer')
+    autoprefixer = require('gulp-autoprefixer'),
     assign = require('lodash.assign');
 
 var defaultOptions = {
   src: 'app/theme/app.+(ios|md|wp).scss',
+  srcOptions: {},
   dest: 'www/build/css',
   sassOptions: {
     includePaths: [
@@ -31,7 +32,7 @@ var defaultOptions = {
 module.exports = function(options) {
   options = assign(defaultOptions, options);
 
-  return gulp.src(options.src)
+  return gulp.src(options.src, options.srcOptions)
     .pipe(sass(options.sassOptions))
     .on('error', options.onError)
     .pipe(autoprefixer(options.autoprefixerOptions))

--- a/sass-build/index.js
+++ b/sass-build/index.js
@@ -23,6 +23,7 @@ var defaultOptions = {
     ],
     cascade: false
   },
+  hookFunction: function(stream) { return stream; },
   onError: function(err) {
     console.error(err.message);
     this.emit('end'); // Don't kill watch tasks - https://github.com/gulpjs/gulp/issues/259
@@ -32,9 +33,11 @@ var defaultOptions = {
 module.exports = function(options) {
   options = assign(defaultOptions, options);
 
-  return gulp.src(options.src, options.srcOptions)
+  var stream = gulp.src(options.src, options.srcOptions)
     .pipe(sass(options.sassOptions))
     .on('error', options.onError)
-    .pipe(autoprefixer(options.autoprefixerOptions))
+    .pipe(autoprefixer(options.autoprefixerOptions));
+
+  return options.hookFunction(stream)
     .pipe(gulp.dest(options.dest));
 }


### PR DESCRIPTION
We need to apply extra transformations to our sass build. ionic-gulp-sass-build doesn't allow us to pipe such transformations. In order to keep ionic's default values and pipe additional transformations I suggest a hook function is added to the options object.

Here, I added the following properties:
- `srcOptions`: because we need to set the `{base: 'abc/abc'}` options for `gulp.src`
- `hookFunction`: it enables us to set our extra transformations. ie:
  
  ``` javascript
  options = {
   hookFunction: function(stream) {
     return stream.pipe(mySuperTransformation());
   }
  }
  ```
