### PR TITLE
fix(Webpack): fix webpack callback for fatal error

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -26,11 +26,23 @@ module.exports = function(options) {
   }
 
   function webpackCallback(err, stats) {
-    // print build stats and errors
-    console.log(stats.toString(options.statsOptions));
-    if (stats.hasErrors() ||
-      (stats.hasWarnings() && options.failOnWarning)) {
+    if (err) {
+      // handle fatal error
       deferred.reject(err);
+      return
+    } else if (stats) {
+      // print build stats and errors
+      console.log(stats.toString(options.statsOptions));
+      var jsonStats = stats.toJson();
+      if (stats.hasErrors()) {
+        // handle soft errors
+        deferred.reject(jsonStats.errors);
+        return
+      } else if (stats.hasWarnings() && options.failOnWarning) {
+        // handle warnings
+        deferred.reject(jsonStats.warnings);
+        return
+      }
     }
 
     deferred.resolve();


### PR DESCRIPTION
According to the implementation of the [run method of webpack
compiler](https://github.com/webpack/webpack/blob/master/lib/Compiler.js
# L180), the callback function can be called without passing any `stats`

in the case of a fatal error, e.g. when using the option `bail` of
webpack.

fix #46
