### PR TITLE
VCS like tfs will mark all loc files as read only

### DIFF
--- a/html-copy/index.js
+++ b/html-copy/index.js
@@ -5,5 +5,5 @@ module.exports = function(options) {
   options.dest = options.dest || 'www/build';
 
   return gulp.src(options.src)
-    .pipe(gulp.dest(options.dest));
+    .pipe(gulp.dest(options.dest, {"mode": "0777"}));
 }


### PR DESCRIPTION
gulp can't overwrite for the second time. It will throw the error below.

ionic $ [16:56:44] Starting 'html'...
[16:56:44] 'html' errored after 23 ms
[16:56:44] Error: EPERM: operation not permitted, open 'D:\SOURCE_CONTROL\TFS\MYAPP\www\build\pages\home\home.html'
    at Error (native)
