### PR TITLE
Bump browserify-typescript tsify dependency version to at least 0.15.6

### DIFF
--- a/browserify-typescript/package.json
+++ b/browserify-typescript/package.json
@@ -14,7 +14,7 @@
     "gulp-uglify": "^1.5.3",
     "lodash.merge": "^4.3.2",
     "prettysize": "0.0.3",
-    "tsify": "^0.14.1",
+    "tsify": "^0.15.6",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Please bump tsify version as it adds `global` option that can be used in tsifyOptions which helps when importing TypeScript modules directly from `node_modules` dir
